### PR TITLE
Fix spec to make it work as a cocoapods framework

### DIFF
--- a/curly.podspec
+++ b/curly.podspec
@@ -15,6 +15,7 @@ Pod::Spec.new do |s|
   
   s.pod_target_xcconfig = {
     "HEADER_SEARCH_PATHS" => '"$(PODS_ROOT)/curly/third-party/curl/ios/include"',
+    "LIBRARY_SEARCH_PATHS" => '$(inherited) "$(PODS_ROOT)/curly/third-party/curl/ios/lib"'
   }
   
   s.user_target_xcconfig = {
@@ -22,6 +23,6 @@ Pod::Spec.new do |s|
     "ENABLE_BITCODE" => "NO"
   }
   
-  s.libraries = "curl"
+  s.libraries = "curl", "z"
   s.frameworks = "Foundation"
 end


### PR DESCRIPTION
This changes are needed to make it compile as a framework, which is required by projects using Cocoapods dependencies written in Swift.
